### PR TITLE
updated options style.

### DIFF
--- a/bin/shellpop
+++ b/bin/shellpop
@@ -404,7 +404,7 @@ def generate_file_name(extension=""):
 
 def header():
     contributors = ["@zc00l", "@touhidshaikh", "@lowfuel"]
-    return "\033[093mshellpop\033[0m v{0}\n\033[93mcontributors\033[0m: {1}\n\n".format(version, ','.join([x for x in contributors]))
+    return "\033[093mshellpop\033[0m v{0}\n\033[93mContributors\033[0m: {1}\n\n".format(version, ','.join([x for x in contributors]))
 
 def select_shell(args, shell_type, shell_index):
 
@@ -438,35 +438,45 @@ def select_shell(args, shell_type, shell_index):
 
 
 def main():
-    parser = ArgumentParser()
-    
+    parser = ArgumentParser(epilog='Pop shells like a master. For more help visit:https://github.com/0x00-0x00/ShellPop')
+    parser._optionals.title = "Options"
+
     # List mode
-    parser.add_argument("--list", help="List of available shells", action="store_true")
+    parser.add_argument("-l","--list", help="List of available shells", action="store_true")
     
     # Program parameters
-    parser.add_argument("--host", type=str, help="IP to be used in connectback (reverse) shells.")
-    parser.add_argument("--port", type=int, help="Port to be used in reverse/bind shell code.")
+    parser.add_argument("-H","--host", type=str, help="IP to be used in connectback (reverse) shells.")
+    parser.add_argument("-P","--port", type=int, help="Port to be used in reverse/bind shell code.")
     parser.add_argument("--number", type=int, help="Shell code index number", required=False)
-    parser.add_argument("--reverse", action="store_true")
-    parser.add_argument("--bind", action="store_true")
     parser.add_argument("--shell", type=str, default="", help="Terminal shell to be used when decoding some encoding scheme.", required=False)
 
+
+    #Shell Type
+    shelltype = parser.add_argument_group('Shell Types')
+    shelltype.add_argument("--reverse", action="store_true", help="Victim communicates back to the attacking machine.")
+    shelltype.add_argument("--bind", action="store_true",help="Open up a listener on the victim machine.")
+
     # Available encodings
-    parser.add_argument("--xor", action="store_true",help="Enable XOR obfuscation", required=False)
-    parser.add_argument("--base64", action="store_true", required=False, help="Encode command in base64.")
-    parser.add_argument("--urlencode", action="store_true", required=False, help="Encode the command in URL encoding.")
+    encoders = parser.add_argument_group('Encoders Options')
+    encoders.add_argument("--xor", action="store_true",help="Enable XOR obfuscation", required=False)
+    encoders.add_argument("--base64", action="store_true", required=False, help="Encode command in base64.")
+    encoders.add_argument("--urlencode", action="store_true", required=False, help="Encode the command in URL encoding.")
 
     # Use handler if possible.
     parser.add_argument("--handler", action="store_true", help="Use handler, if possible.", default=False, required=False)
 
+    #Stagging 
+    stagingarg = parser.add_argument_group("Stagging Options")
     # Use staging
-    parser.add_argument("--stager", type=str, help="Use HTTP staging for malicious shells", required=False)
-
+    stagingarg.add_argument("--stager", type=str, help="Use HTTP staging for malicious shells", required=False)
     # Http-staging options
-    parser.add_argument("--http-port", type=int, help="HTTP staging port to be used", required=False)
+    stagingarg.add_argument("--http-port", type=int, help="HTTP staging port to be used", required=False)
+
+    #Miscellaneous 
+    miscarg = parser.add_argument_group("Miscellaneous")
 
     # Send it to clipboard
-    parser.add_argument("--clip", action="store_true", help="Copy payload to your clipboard automatically.", default=False, required=False)
+    miscarg.add_argument("--clip", action="store_true", help="Copy payload to your clipboard automatically.", default=False, required=False)
 
     args = parser.parse_args()
     if args.list == True:
@@ -476,7 +486,8 @@ def main():
 
     if type(args.number) is not int:
         write(header())
-        print(error("Error: You need to select a shell using --number. To list shells, use: --list"))
+        print(error("Error: You need to select a shell using --number. To list shells use: --list"))
+        print(error("For Help use: --help or -h options"))
         exit(1)
 
     if args.reverse is True and args.bind is True:


### PR DESCRIPTION
hey mate, i have updated style of options..... take a look if its look good than merge it.... or if u have any suggestion for this PR let me know...

Now Its look like below output
```
usage: shellpop [-h] [-l] [-H HOST] [-P PORT] [--number NUMBER]
                [--shell SHELL] [--reverse] [--bind] [--xor] [--base64]
                [--urlencode] [--handler] [--stager STAGER]
                [--http-port HTTP_PORT] [--clip]

Options:
  -h, --help            show this help message and exit
  -l, --list            List of available shells
  -H HOST, --host HOST  IP to be used in connectback (reverse) shells.
  -P PORT, --port PORT  Port to be used in reverse/bind shell code.
  --number NUMBER       Shell code index number
  --shell SHELL         Terminal shell to be used when decoding some encoding
                        scheme.
  --handler             Use handler, if possible.

Shell Types:
  --reverse             Victim communicates back to the attacking machine.
  --bind                Open up a listener on the victim machine.

Encoders Options:
  --xor                 Enable XOR obfuscation
  --base64              Encode command in base64.
  --urlencode           Encode the command in URL encoding.

Stagging Options:
  --stager STAGER       Use HTTP staging for malicious shells
  --http-port HTTP_PORT
                        HTTP staging port to be used

Miscellaneous:
  --clip                Copy payload to your clipboard automatically.

Pop shells like a master. For more help
visit:https://github.com/0x00-0x00/ShellPop
```

What do u think about this ... just review it and let me know. ;) 